### PR TITLE
Feature/dp 63 refresh token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,14 @@ HELP.md
 README.md
 
 application-*.properties
+
+# ===================
+# 🗄️ H2 Database
+# ===================
+
+# H2 DB 파일 (예: ./data/testdb.mv.db)
+*.mv.db
+*.trace.db
+
+# H2 저장 디렉터리 (예: ./data/)
+data/

--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,5 @@ application-*.properties
 
 # H2 저장 디렉터리 (예: ./data/)
 data/
+
+docker-compose.yml

--- a/docker-compose-template.yml
+++ b/docker-compose-template.yml
@@ -1,0 +1,9 @@
+version: "3.8"
+services:
+  redis:
+    image: redis:7.2-alpine
+    container_name: redis
+    ports:
+      - "6379:6379"
+    restart: unless-stopped
+    command: ["redis-server", "--requirepass", "${REDIS_PASSWORD}"]

--- a/src/main/java/com/deepdirect/deepwebide_be/global/config/RedisConfig.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/global/config/RedisConfig.java
@@ -1,0 +1,14 @@
+package com.deepdirect.deepwebide_be.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+public class RedisConfig {
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        return new StringRedisTemplate(redisConnectionFactory);
+    }
+}

--- a/src/main/java/com/deepdirect/deepwebide_be/global/security/RefreshToken.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/global/security/RefreshToken.java
@@ -1,0 +1,18 @@
+package com.deepdirect.deepwebide_be.global.security;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@RedisHash(value = "refreshToken", timeToLive = 60 * 60 * 24 * 14) // 2주 (초 단위)
+public class RefreshToken {
+    @Id
+    private String userId;   // 사용자 ID (Long 타입일 경우 toString 변환)
+    private String token;    // 리프레시 토큰 값
+}

--- a/src/main/java/com/deepdirect/deepwebide_be/global/security/RefreshTokenService.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/global/security/RefreshTokenService.java
@@ -10,11 +10,13 @@ import java.time.Duration;
 @RequiredArgsConstructor
 public class RefreshTokenService {
     private final StringRedisTemplate redisTemplate;
+    private final JwtTokenProvider jwtTokenProvider;
 
     // 리프레시 토큰 저장 (userId를 Long으로 받아 String으로 변환)
-    public void save(Long userId, String refreshToken, long expireSeconds) {
+    public void save(Long userId, String refreshToken) {
+        long expireMillis = jwtTokenProvider.getRefreshTokenExpireMillis();
         redisTemplate.opsForValue()
-                .set(String.valueOf(userId), refreshToken, Duration.ofSeconds(expireSeconds));
+                .set(String.valueOf(userId), refreshToken, Duration.ofMillis(expireMillis));
     }
 
     // 리프레시 토큰 조회

--- a/src/main/java/com/deepdirect/deepwebide_be/global/security/RefreshTokenService.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/global/security/RefreshTokenService.java
@@ -1,0 +1,35 @@
+package com.deepdirect.deepwebide_be.global.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@RequiredArgsConstructor
+@Service
+public class RefreshTokenService {
+    private final StringRedisTemplate redisTemplate;
+    private static final long REFRESH_TOKEN_EXPIRE_DAYS = 14; // 2주
+
+    // 저장
+    public void saveRefreshToken(Long userId, String refreshToken) {
+        redisTemplate.opsForValue().set(
+                getKey(userId),
+                refreshToken,
+                REFRESH_TOKEN_EXPIRE_DAYS,
+                TimeUnit.DAYS
+        );
+    }
+    // 조회
+    public String getRefreshToken(Long userId) {
+        return redisTemplate.opsForValue().get(getKey(userId));
+    }
+    // 삭제
+    public void deleteRefreshToken(Long userId) {
+        redisTemplate.delete(getKey(userId));
+    }
+    private String getKey(Long userId) {
+        return "refresh:" + userId;
+    }
+}

--- a/src/main/java/com/deepdirect/deepwebide_be/global/security/RefreshTokenService.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/global/security/RefreshTokenService.java
@@ -4,32 +4,26 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
-@RequiredArgsConstructor
 @Service
+@RequiredArgsConstructor
 public class RefreshTokenService {
     private final StringRedisTemplate redisTemplate;
-    private static final long REFRESH_TOKEN_EXPIRE_DAYS = 14; // 2주
 
-    // 저장
-    public void saveRefreshToken(Long userId, String refreshToken) {
-        redisTemplate.opsForValue().set(
-                getKey(userId),
-                refreshToken,
-                REFRESH_TOKEN_EXPIRE_DAYS,
-                TimeUnit.DAYS
-        );
+    // 리프레시 토큰 저장 (userId를 Long으로 받아 String으로 변환)
+    public void save(Long userId, String refreshToken, long expireSeconds) {
+        redisTemplate.opsForValue()
+                .set(String.valueOf(userId), refreshToken, Duration.ofSeconds(expireSeconds));
     }
-    // 조회
-    public String getRefreshToken(Long userId) {
-        return redisTemplate.opsForValue().get(getKey(userId));
+
+    // 리프레시 토큰 조회
+    public String findByUserId(Long userId) {
+        return redisTemplate.opsForValue().get(String.valueOf(userId));
     }
-    // 삭제
-    public void deleteRefreshToken(Long userId) {
-        redisTemplate.delete(getKey(userId));
-    }
-    private String getKey(Long userId) {
-        return "refresh:" + userId;
+
+    // 리프레시 토큰 삭제
+    public void delete(Long userId) {
+        redisTemplate.delete(String.valueOf(userId));
     }
 }

--- a/src/main/java/com/deepdirect/deepwebide_be/global/security/SecurityConfiguration.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/global/security/SecurityConfiguration.java
@@ -57,6 +57,7 @@ public class SecurityConfiguration {
                                 new AntPathRequestMatcher("/api/auth/**"),
                                 new AntPathRequestMatcher("/h2-console/**")
                         ).permitAll()
+                        .requestMatchers(new AntPathRequestMatcher("/api/auth/signout")).authenticated()
                         .anyRequest().authenticated()
                 )
                 .httpBasic(Customizer.withDefaults())

--- a/src/main/java/com/deepdirect/deepwebide_be/member/controller/UserController.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/member/controller/UserController.java
@@ -43,4 +43,12 @@ public class UserController {
         // response(본문)는 AccessToken만, RefreshToken은 쿠키로 헤더에 내려감!
         return ResponseEntity.ok(ApiResponseDto.of(200, "로그인에 성공했습니다.", response));
     }
+
+    @PostMapping("/signout")
+    public ResponseEntity<ApiResponseDto<Void>> signOut(
+            @RequestHeader("Authorization") String authorizationHeader,
+            HttpServletResponse response
+    ) {
+        return userService.signOut(authorizationHeader, response);
+    }
 }

--- a/src/main/java/com/deepdirect/deepwebide_be/member/controller/UserController.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/member/controller/UserController.java
@@ -6,6 +6,7 @@ import com.deepdirect.deepwebide_be.member.dto.request.SignUpRequest;
 import com.deepdirect.deepwebide_be.member.dto.response.SignInResponse;
 import com.deepdirect.deepwebide_be.member.dto.response.SignUpResponse;
 import com.deepdirect.deepwebide_be.member.service.UserService;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -33,8 +34,13 @@ public class UserController {
     }
 
     @PostMapping("/signin")
-    public ResponseEntity<ApiResponseDto<SignInResponse>> signIn(@Valid @RequestBody SignInRequest signInRequest) {
-        SignInResponse response = userService.signIn(signInRequest);
+    public ResponseEntity<ApiResponseDto<SignInResponse>> signIn(
+            @Valid @RequestBody SignInRequest signInRequest,
+            HttpServletResponse servletResponse
+    ) {
+        // 1. 서비스에서 로그인 + 토큰 2개 발급
+        SignInResponse response = userService.signIn(signInRequest, servletResponse);
+        // response(본문)는 AccessToken만, RefreshToken은 쿠키로 헤더에 내려감!
         return ResponseEntity.ok(ApiResponseDto.of(200, "로그인에 성공했습니다.", response));
     }
 }

--- a/src/main/java/com/deepdirect/deepwebide_be/member/controller/UserController.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/member/controller/UserController.java
@@ -49,6 +49,7 @@ public class UserController {
             @RequestHeader("Authorization") String authorizationHeader,
             HttpServletResponse response
     ) {
-        return userService.signOut(authorizationHeader, response);
+        userService.signOut(authorizationHeader, response);
+        return ResponseEntity.ok(ApiResponseDto.of(200, "로그아웃 되었습니다.", null));
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,6 +19,5 @@ spring.jpa.properties.hibernate.format_sql=true
 
 spring.data.redis.host=localhost
 spring.data.redis.port=6379
-spring.data.redis.password=??????
 
 spring.config.import=optional:application-env.properties

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,8 @@
 spring.application.name=deepwebide-be
 
 # H2 Datasource
-spring.datasource.url=jdbc:h2:mem:testdb
+#spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.url=jdbc:h2:file:./data/testdb;DB_CLOSE_ON_EXIT=FALSE;AUTO_SERVER=TRUE
 spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,7 @@ spring.application.name=deepwebide-be
 
 # H2 Datasource
 #spring.datasource.url=jdbc:h2:mem:testdb
-spring.datasource.url=jdbc:h2:file:./data/testdb;DB_CLOSE_ON_EXIT=FALSE;AUTO_SERVER=TRUE
+spring.datasource.url=jdbc:h2:file:./data/testdb;DB_CLOSE_ON_EXIT=FALSE
 spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=
@@ -16,5 +16,9 @@ spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
+
+spring.data.redis.host=localhost
+spring.data.redis.port=6379
+spring.data.redis.password=??????
 
 spring.config.import=optional:application-env.properties

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -1,0 +1,27 @@
+set -e
+
+# 1. 랜덤 비밀번호 생성
+REDIS_PASSWORD=$(LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 16)
+export REDIS_PASSWORD
+
+# 2. docker-compose.yml 생성
+envsubst < docker-compose-template.yml > docker-compose.yml
+
+# 3. application-env.properties에 redis 비번 삽입/치환
+if grep -q '^spring.data.redis.password=' application-env.properties; then
+  sed -i '' "s/^spring\.data\.redis\.password=.*/spring.data.redis.password=$REDIS_PASSWORD/" application-env.properties
+else
+  echo "spring.data.redis.password=$REDIS_PASSWORD" >> application-env.properties
+fi
+
+echo "🧱 Redis 컨테이너 실행 중..."
+docker-compose up -d redis
+
+if [ $? -ne 0 ]; then
+  echo "❌ Redis 실행 실패. 도커 설치 상태나 포트를 확인하세요."
+  exit 1
+fi
+
+echo "✅ Redis 실행 완료."
+echo "🚀 Spring Boot 서버 실행 중..."
+./gradlew bootRun

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -1,5 +1,8 @@
 set -e
 
+# 0. application-env.properties 경로 변수
+ENV_FILE="src/main/resources/application-env.properties"
+
 # 1. 랜덤 비밀번호 생성
 REDIS_PASSWORD=$(LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 16)
 export REDIS_PASSWORD
@@ -8,10 +11,10 @@ export REDIS_PASSWORD
 envsubst < docker-compose-template.yml > docker-compose.yml
 
 # 3. application-env.properties에 redis 비번 삽입/치환
-if grep -q '^spring.data.redis.password=' application-env.properties; then
-  sed -i '' "s/^spring\.data\.redis\.password=.*/spring.data.redis.password=$REDIS_PASSWORD/" application-env.properties
+if grep -q '^spring.data.redis.password=' "$ENV_FILE"; then
+  sed -i '' "s/^spring\.data\.redis\.password=.*/spring.data.redis.password=$REDIS_PASSWORD/" "$ENV_FILE"
 else
-  echo "spring.data.redis.password=$REDIS_PASSWORD" >> application-env.properties
+  echo "spring.data.redis.password=$REDIS_PASSWORD" >> "$ENV_FILE"
 fi
 
 echo "🧱 Redis 컨테이너 실행 중..."


### PR DESCRIPTION
## 🔀 PR 제목

- [Feature] Redis 연동 및 JWT 기반 인증/로그아웃 구현
- [Feature] Redis Docker Compose 적용 및 비밀번호 자동화

---

## 📌 작업 내용 요약

- H2 설정 변경:
  - In-memory 방식 → 파일 기반(file-based)으로 전환
  - 재시작 시 데이터 유지 가능하도록 jdbc:h2:file: 형식으로 수정

- Redis 연동:
  - Docker Compose로 Redis 컨테이너 관리
  - 랜덤 비밀번호 자동 생성 및 application-env.properties 반영
  - StringRedisTemplate 기반 RefreshTokenService 구현

- JWT 인증:
   - JWT Access/Refresh Token 발급 및 검증
   - 로그인 시 AccessToken(Body), RefreshToken(HTTP Only Cookie) 발급
   - 로그아웃 시 RefreshToken Redis 삭제 + 쿠키 만료처리

- Spring Security:
  - 인증/비인증 경로 정책 리팩토링
  - /api/auth/signin, /api/auth/signup만 permitAll
  - /api/auth/signout 등은 인증 필요하도록 설정

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [ ] 기능 요구사항을 모두 구현했나요?
- [ ] 로컬에서 기능을 직접 테스트했나요?
- [ ] 코드 컨벤션 및 스타일을 지켰나요?
- [ ] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

- Closes #21 
- Related to #12
---

## 📎 기타 참고 사항

- Redis 비밀번호 자동화:
  - 배포시 민감정보 노출 방지, 개발/테스트는 고정 패스워드 가능
  - application-env.properties와 docker-compose-template.yml 동기화
- RefreshToken 만료:
  - Redis TTL 정상 반영, 직접 TTL 조회/테스트 완료
- H2 .gitignore 처리:
  - *.mv.db, *.trace.db, /data/ 디렉터리 등 Git 추적에서 제외
  - 로컬 개발 중 데이터 보존 목적
  - 공유가 필요한 경우 별도 data.sql 등 Seed 데이터 관리 필요