### PR TITLE
Feature/dp 72 settings

### DIFF
--- a/src/main/java/com/deepdirect/deepwebide_be/global/exception/ErrorCode.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/global/exception/ErrorCode.java
@@ -68,6 +68,8 @@ public enum ErrorCode {
     PRODUCT_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "상품 이미지가 존재하지 않습니다."),
     VERIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "인증 요청 기록이 없습니다."),
     REPOSITORY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않은 레포지토리 입니다."),
+    ENTRY_CODE_NOT_FOUND(HttpStatus.NOT_FOUND, "입장 코드를 찾을 수 없습니다."),
+
 
     // 409 CONFLICT
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 가입된 이메일입니다."),

--- a/src/main/java/com/deepdirect/deepwebide_be/global/exception/ErrorCode.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/global/exception/ErrorCode.java
@@ -25,7 +25,6 @@ public enum ErrorCode {
     ORDER_ALREADY_CANCELED(HttpStatus.BAD_REQUEST, "이미 취소된 주문입니다."),
     REPOSITORY_NAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST,"이미 동일한 이름의 레포지토리가 존재합니다."),
     REPOSITORY_NOT_SHARED(HttpStatus.BAD_REQUEST, "공유된 레포지토리가 아닙니다."),
-    ENTRY_CODE_ACCESS_DENIED(HttpStatus.BAD_REQUEST, "오너만 확인할 수 있습니다."),
     ENTRY_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "입장 코드가 만료되었습니다."),
 
 
@@ -53,6 +52,9 @@ public enum ErrorCode {
     // 403 FORBIDDEN
     FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
     EMAIL_NOT_VERIFIED(HttpStatus.FORBIDDEN, "이메일 인증을 완료해야 로그인할 수 있습니다."),
+    ENTRY_CODE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "오너만 확인할 수 있습니다."),
+    ENTRY_CODE_REISSUE_DENIED(HttpStatus.FORBIDDEN, "해당 레포지토리의 소유자만 입장 코드를 재발급할 수 있습니다."),
+
 
     // 404 NOT FOUND
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),

--- a/src/main/java/com/deepdirect/deepwebide_be/repository/controller/RepositoryEntryCodeController.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/repository/controller/RepositoryEntryCodeController.java
@@ -8,10 +8,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,4 +29,20 @@ public class RepositoryEntryCodeController {
         RepositoryEntryCodeResponse response = entryCodeService.getEntryCode(repositoryId, userDetails.getId());
         return ResponseEntity.ok(ApiResponseDto.of(200, "입장코드 확인이 성공했습니다.", response));
     }
+
+    @PostMapping("/{repositoryId}/new-entrycode")
+    public ResponseEntity<ApiResponseDto<Map<String, String>>> regenerateEntryCode(
+            @PathVariable Long repositoryId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        String newCode = entryCodeService.regenerateEntryCode(repositoryId, userDetails.getId());
+
+        Map<String, String> data = new HashMap<>();
+        data.put("newEntryCode", newCode);
+
+        return ResponseEntity.ok(
+                ApiResponseDto.of(200, "입장코드가 재발급 되셨습니다.", data)
+        );
+    }
+
 }

--- a/src/main/java/com/deepdirect/deepwebide_be/repository/domain/RepositoryEntryCode.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/repository/domain/RepositoryEntryCode.java
@@ -43,5 +43,11 @@ public class RepositoryEntryCode {
         this.repository = repository;
     }
 
+    public void updateEntryCode(String newCode, LocalDateTime newExpiresAt) {
+        this.entryCode = newCode;
+        this.expiresAt = newExpiresAt;
+    }
+
+
 }
 

--- a/src/main/java/com/deepdirect/deepwebide_be/repository/repository/RepositoryEntryCodeRepository.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/repository/repository/RepositoryEntryCodeRepository.java
@@ -11,4 +11,6 @@ public interface RepositoryEntryCodeRepository extends JpaRepository<RepositoryE
     Optional<RepositoryEntryCode> findByRepositoryIdAndExpiresAtAfter(Long repositoryId, LocalDateTime now);
 
     boolean existsByEntryCode(String entryCode);
+
+    Optional<RepositoryEntryCode> findByRepositoryId(Long id);
 }

--- a/src/main/java/com/deepdirect/deepwebide_be/repository/service/RepositoryEntryCodeService.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/repository/service/RepositoryEntryCodeService.java
@@ -7,6 +7,7 @@ import com.deepdirect.deepwebide_be.repository.domain.RepositoryEntryCode;
 import com.deepdirect.deepwebide_be.repository.dto.response.RepositoryEntryCodeResponse;
 import com.deepdirect.deepwebide_be.repository.repository.RepositoryEntryCodeRepository;
 import com.deepdirect.deepwebide_be.repository.repository.RepositoryRepository;
+import com.deepdirect.deepwebide_be.repository.util.EntryCodeGenerator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,10 +24,7 @@ public class RepositoryEntryCodeService {
     private final RepositoryRepository repositoryRepository;
     private final RepositoryEntryCodeRepository entryCodeRepository;
 
-    private static final int ENTRY_CODE_LENGTH = 8;
-    private static final int MAX_TRY_COUNT = 10;
-
-    @Transactional(readOnly = true)
+    @Transactional
     public RepositoryEntryCodeResponse getEntryCode(Long repositoryId, Long userId) {
 
         Repository repo = repositoryRepository.findById(repositoryId)
@@ -40,8 +38,9 @@ public class RepositoryEntryCodeService {
             throw new GlobalException(ErrorCode.REPOSITORY_NOT_SHARED);
         }
 
-        RepositoryEntryCode entryCode = entryCodeRepository.findByRepositoryIdAndExpiresAtAfter(repo.getId(), LocalDateTime.now())
-                .orElseGet(() -> createNewEntryCode(repo));
+        RepositoryEntryCode entryCode = entryCodeRepository
+                .findByRepositoryIdAndExpiresAtAfter(repo.getId(), LocalDateTime.now())
+                .orElseGet(() -> regenerateEntryCodeInternal(repo));
 
         return RepositoryEntryCodeResponse.builder()
                 .repositoryId(repo.getId())
@@ -69,41 +68,20 @@ public class RepositoryEntryCodeService {
             throw new GlobalException(ErrorCode.REPOSITORY_NOT_SHARED);
         }
 
-        RepositoryEntryCode newCode = createNewEntryCode(repo);
-        return newCode.getEntryCode();
+        return regenerateEntryCodeInternal(repo).getEntryCode();
     }
 
+    /**
+     * 내부에서 엔트리 코드를 재생성하고 업데이트하는 로직
+     */
+    private RepositoryEntryCode regenerateEntryCodeInternal(Repository repo) {
+        RepositoryEntryCode entryCode = entryCodeRepository.findByRepositoryId(repo.getId())
+                .orElseThrow(() -> new GlobalException(ErrorCode.ENTRY_CODE_NOT_FOUND));
 
-
-    private RepositoryEntryCode createNewEntryCode(Repository repo) {
-        String code = generateUniqueEntryCode();
-
-        RepositoryEntryCode entryCode = RepositoryEntryCode.builder()
-                .repository(repo)
-                .entryCode(code)
-                .expiresAt(LocalDateTime.now().plusDays(3))
-                .build();
-
-        return entryCodeRepository.save(entryCode);
+        String newCode = EntryCodeGenerator.generateUniqueCode(entryCodeRepository::existsByEntryCode);
+        entryCode.updateEntryCode(newCode, LocalDateTime.now().plusDays(3));
+        return entryCode;
     }
 
-    private String generateUniqueEntryCode() {
-        for (int i = 0; i < MAX_TRY_COUNT; i++) {
-            String code = generateRandomCode(ENTRY_CODE_LENGTH);
-            boolean exists = entryCodeRepository.existsByEntryCode(code);
-            if (!exists) return code;
-        }
-        throw new GlobalException(ErrorCode.ENTRY_CODE_GENERATION_FAILED);
-    }
-
-    private String generateRandomCode(int length) {
-        String chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-        StringBuilder sb = new StringBuilder(length);
-        ThreadLocalRandom random = ThreadLocalRandom.current();
-        for (int i = 0; i < length; i++) {
-            sb.append(chars.charAt(random.nextInt(chars.length())));
-        }
-        return sb.toString();
-    }
 }
 

--- a/src/main/java/com/deepdirect/deepwebide_be/repository/service/RepositoryEntryCodeService.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/repository/service/RepositoryEntryCodeService.java
@@ -56,6 +56,24 @@ public class RepositoryEntryCodeService {
                 .build();
     }
 
+    @Transactional
+    public String regenerateEntryCode(Long repositoryId, Long userId) {
+        Repository repo = repositoryRepository.findById(repositoryId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.REPOSITORY_NOT_FOUND));
+
+        if (!repo.getOwner().getId().equals(userId)) {
+            throw new GlobalException(ErrorCode.ENTRY_CODE_REISSUE_DENIED);
+        }
+
+        if (!repo.isShared()) {
+            throw new GlobalException(ErrorCode.REPOSITORY_NOT_SHARED);
+        }
+
+        RepositoryEntryCode newCode = createNewEntryCode(repo);
+        return newCode.getEntryCode();
+    }
+
+
 
     private RepositoryEntryCode createNewEntryCode(Repository repo) {
         String code = generateUniqueEntryCode();

--- a/src/main/java/com/deepdirect/deepwebide_be/repository/util/EntryCodeGenerator.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/repository/util/EntryCodeGenerator.java
@@ -1,0 +1,38 @@
+package com.deepdirect.deepwebide_be.repository.util;
+
+import com.deepdirect.deepwebide_be.global.exception.ErrorCode;
+import com.deepdirect.deepwebide_be.global.exception.GlobalException;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Function;
+
+public class EntryCodeGenerator {
+
+    private static final int CODE_LENGTH = 8;
+    private static final int MAX_TRY_COUNT = 10;
+    private static final String CHAR_POOL = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+    private EntryCodeGenerator() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    public static String generateUniqueCode(Function<String, Boolean> isDuplicate) {
+        for (int i = 0; i < MAX_TRY_COUNT; i++) {
+            String code = generateRandomCode(CODE_LENGTH);
+            if (!isDuplicate.apply(code)) {
+                return code;
+            }
+        }
+        throw new GlobalException(ErrorCode.ENTRY_CODE_GENERATION_FAILED);
+    }
+
+    private static String generateRandomCode(int length) {
+        StringBuilder sb = new StringBuilder(length);
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        for (int i = 0; i < length; i++) {
+            sb.append(CHAR_POOL.charAt(random.nextInt(CHAR_POOL.length())));
+        }
+        return sb.toString();
+    }
+
+}


### PR DESCRIPTION
## 🔀 PR 제목
- [Feature] 입장 코드 재발급 API 구현

---

## 📌 작업 내용 요약
어떤 작업을 했는지 간략히 설명해주세요.

- 공유된 레포지토리의 소유자만 입장 코드 재발급 가능
- 만료 여부와 상관없이 항상 새로운 코드로 갱신
- 코드 생성 시 랜덤 8자리 + 중복 체크 방식
- EntryCodeGenerator 유틸 클래스 분리
- RepositoryEntryCode 엔티티에 updateEntryCode() 도메인 메서드 추가

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

- Closes #32 
- Related to #32 
---

## 📎 기타 참고 사항
추가로 리뷰어가 참고해야 할 사항이 있다면 적어주세요.

- EntryCodeGenerator 유틸은 추후 입장 코드 생성 로직에서 재사용 가능
