### PR TITLE
fix(repo): 레포 생성 시 오너도 repository_members에 추가 및 관련 로직 추가 DP-106

### DIFF
--- a/src/main/java/com/deepdirect/deepwebide_be/repository/service/RepositoryService.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/repository/service/RepositoryService.java
@@ -53,6 +53,13 @@ public class RepositoryService {
 
         Repository savedRepository = repositoryRepository.save(repository);
 
+        RepositoryMember ownerMember = RepositoryMember.builder()
+                .repository(savedRepository)
+                .user(owner)
+                .role(RepositoryMemberRole.OWNER)
+                .build();
+        repositoryMemberRepository.save(ownerMember);
+
         return RepositoryCreateResponse.builder()
                 .repositoryId(savedRepository.getId())
                 .repositoryName(savedRepository.getRepositoryName())
@@ -222,6 +229,10 @@ public class RepositoryService {
         if (repo.isShared()) {
             throw new GlobalException(ErrorCode.CANNOT_DELETE_SHARED_REPOSITORY);
         }
+
+        repositoryMemberRepository
+                .findByRepositoryIdAndUserIdAndDeletedAtIsNull(repositoryId, userId)
+                .ifPresent(RepositoryMember::softDelete);
 
         repo.softDelete();
     }


### PR DESCRIPTION
## 🔀 PR 제목

- [Fix] 레포 생성 시 오너 member 등록 및 삭제 시 soft delete 처리

---

## 📌 작업 내용 요약
어떤 작업을 했는지 간략히 설명해주세요.

- 레포 생성 시 repository_members 테이블에 오너(OWNER) 등록 로직 추가
- 레포 삭제 시 오너의 repository_members 레코드를 soft delete 처리
- 공유 레포 환경설정 조회 시 오너 정보가 members에 표시되지 않던 문제 해결
---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
`Closes #이슈번호` 또는 `Related to #이슈번호` 형태로 작성

- Closes #73 
- Related to #73 
---

## 📎 기타 참고 사항
추가로 리뷰어가 참고해야 할 사항이 있다면 적어주세요.

예시:
- API 명세 변경사항 포함됨
- 테스트 코드는 다음 PR에서 작성 예정

- 생성
<img width="1479" height="1078" alt="image" src="https://github.com/user-attachments/assets/2d55f2ce-f711-4a49-b929-c3e2b60a48e0" />


<img width="1085" height="354" alt="image" src="https://github.com/user-attachments/assets/7eb5b17f-0231-4818-80b3-9355c8c19204" />

- 삭제
<img width="1479" height="1078" alt="image" src="https://github.com/user-attachments/assets/290c8fee-fea2-4445-a5f0-1bae04ab4398" />

<img width="1084" height="352" alt="image" src="https://github.com/user-attachments/assets/c2b00a8e-88c6-410e-9766-581ab428c820" />

- 환경설정 조회 시 OWNER 표시
<img width="1479" height="1078" alt="image" src="https://github.com/user-attachments/assets/57cf698f-c89c-47c3-ac35-bfaf2855d5e1" />

