### PR TITLE
feat(공유 취소하기): 공유 취소하기 시 RepositoryMember에서 멤버가 삭제되지 않는 문제 DP-107

### DIFF
--- a/src/main/java/com/deepdirect/deepwebide_be/repository/repository/RepositoryFavoriteRepository.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/repository/repository/RepositoryFavoriteRepository.java
@@ -15,4 +15,6 @@ public interface RepositoryFavoriteRepository extends JpaRepository<RepositoryFa
 
     //삭제
     void deleteByUserAndRepository(User user, com.deepdirect.deepwebide_be.repository.domain.Repository repository);
+
+
 }

--- a/src/main/java/com/deepdirect/deepwebide_be/repository/repository/RepositoryMemberRepository.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/repository/repository/RepositoryMemberRepository.java
@@ -16,6 +16,7 @@ public interface RepositoryMemberRepository extends JpaRepository<RepositoryMemb
     Optional<RepositoryMember> findByRepositoryIdAndUserIdAndDeletedAtIsNull(Long repositoryId, Long userId);
     Optional<RepositoryMember> findByRepositoryIdAndUserIdAndDeletedAtIsNotNull(Long repositoryId, Long userId);
     List<RepositoryMember> findAllByRepositoryId(Long repositoryId);
+    List<RepositoryMember> findAllByRepositoryIdAndDeletedAtIsNull(Long repositoryId);
 
     // 존재 확인
     boolean existsByRepositoryIdAndUserIdAndDeletedAtIsNull(Long repositoryId, Long userId);


### PR DESCRIPTION
## 🔀 PR 제목
- [Fix] 공유 취소하기 시 RepositoryMember에서 멤버가 삭제되지 않는 문제 해결

---

## 📌 작업 내용 요약
어떤 작업을 했는지 간략히 설명해주세요.

- 공유하기 취소했을 때 RepositoryMember 테이블에서 Member 삭제되지 않는 문제 발생
- 공유 취소 시 RepositoryMember 테이블의 Owner를 제외한 모든 Member가 deleted_at 컬럼 추가 (softDelete)
- 다시 공유하기 후 입장코드를 통해 다시 입실하면 deleted_at은 사라짐 (restore. 나가거나 추방했다가 다시 들어오는 것과 같은 로직)

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [ ] 기능 요구사항을 모두 구현했나요?
- [ ] 로컬에서 기능을 직접 테스트했나요?
- [ ] 코드 컨벤션 및 스타일을 지켰나요?
- [ ] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
`Closes #이슈번호` 또는 `Related to #이슈번호` 형태로 작성


- Closes #75 
- Related to #75

## 🧪 테스트 결과 
- 현재 공유한 레포지토리 두개 존재 -> 이 중 두번째 레포를 이용(repository_id = 9)
<img width="560" height="627" alt="스크린샷 2025-07-24 오후 7 38 44" src="https://github.com/user-attachments/assets/51b69997-a9f1-418d-b5e8-8f7e538f645e" />

- 다른 유저가 레포지토리에 들어옴
<img width="752" height="85" alt="스크린샷 2025-07-24 오후 7 40 06" src="https://github.com/user-attachments/assets/23a947bd-39f6-45aa-a357-56515a39b293" />

- 오너가 공유하기를 취소
<img width="2141" height="1060" alt="스크린샷 2025-07-24 오후 7 41 10" src="https://github.com/user-attachments/assets/7b9037c9-d99f-42b4-a6bc-e1e96410e961" />

- 오너가 공유하기 취소 이후 DB상에 오너 이외에 멤버는 deletedAt 표기
<img width="747" height="68" alt="스크린샷 2025-07-24 오후 7 41 38" src="https://github.com/user-attachments/assets/4e3d8bc4-3a63-4e03-8fc7-2b09e160e339" />

- 공유하기 이후에 다시 들어가면 deletedAt은 Null로 다시 기입(추방하기나 나가기 했다가 다시 들어오는 것과 같은 논리)
<img width="762" height="73" alt="스크린샷 2025-07-24 오후 7 43 02" src="https://github.com/user-attachments/assets/751dddbe-f9be-45a2-8dc2-ad45f0f169b6" />

- 


---

## 📎 기타 참고 사항
추가로 리뷰어가 참고해야 할 사항이 있다면 적어주세요.
