### PR TITLE
fix(restore 관련 DB 문제 해결): restore 관련 DB 문제 해결 DP-107

### DIFF
--- a/src/main/java/com/deepdirect/deepwebide_be/repository/domain/RepositoryMember.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/repository/domain/RepositoryMember.java
@@ -44,7 +44,5 @@ public class RepositoryMember {
     public void softDelete() {
         this.deletedAt = LocalDateTime.now();
     }
-    public void restore() {
-        this.deletedAt = null;
-    }
+
 }

--- a/src/main/java/com/deepdirect/deepwebide_be/repository/repository/RepositoryMemberRepository.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/repository/repository/RepositoryMemberRepository.java
@@ -14,8 +14,7 @@ public interface RepositoryMemberRepository extends JpaRepository<RepositoryMemb
 
     // 조회
     Optional<RepositoryMember> findByRepositoryIdAndUserIdAndDeletedAtIsNull(Long repositoryId, Long userId);
-    Optional<RepositoryMember> findByRepositoryIdAndUserIdAndDeletedAtIsNotNull(Long repositoryId, Long userId);
-    List<RepositoryMember> findAllByRepositoryId(Long repositoryId);
+    List<RepositoryMember> findAllByRepositoryIdAndDeletedAtIsNull(Long repositoryId);
 
     // 존재 확인
     boolean existsByRepositoryIdAndUserIdAndDeletedAtIsNull(Long repositoryId, Long userId);

--- a/src/main/java/com/deepdirect/deepwebide_be/repository/service/RepositoryService.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/repository/service/RepositoryService.java
@@ -304,7 +304,7 @@ public class RepositoryService {
         List<RepositorySettingResponse.MemberInfo> memberInfos = new ArrayList<>();
 
         if (repository.isShared()) {
-            List<RepositoryMember> members = repositoryMemberRepository.findAllByRepositoryId(repositoryId);
+            List<RepositoryMember> members = repositoryMemberRepository.findAllByRepositoryIdAndDeletedAtIsNull(repositoryId);
             for (RepositoryMember member : members) {
                 User user = member.getUser();
 


### PR DESCRIPTION

## 🔀 PR 제목
- [Fix] Restore로 DeleteAt을 null로 바꾸는 방식 수정 

---

## 📌 작업 내용 요약
어떤 작업을 했는지 간략히 설명해주세요.

추방하기, 나가기, 공유 취소 시 softDelete
- 기존의 방식은 입장코드를 다시 받아서 들어오면 기존의 softDelete된 사용자의 deletedAt을 null로 변환
- 이러면 재방문 시 재방문 시간을 알 수 없음
- 이를 해결하기 위해 재방문 시 무조건 member를 만드는 것으로 변경

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [ ] 기능 요구사항을 모두 구현했나요?
- [ ] 로컬에서 기능을 직접 테스트했나요?
- [ ] 코드 컨벤션 및 스타일을 지켰나요?
- [ ] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
`Closes #이슈번호` 또는 `Related to #이슈번호` 형태로 작성

- Closes #77 
- Related to #77 
---

## 📎 기타 참고 사항
추가로 리뷰어가 참고해야 할 사항이 있다면 적어주세요.

예시:
- API 명세 변경사항 포함됨
- 테스트 코드는 다음 PR에서 작성 예정

## 테스트 
- 공유한 레포지토리 9번을 사용 
<img width="498" height="208" alt="image" src="https://github.com/user-attachments/assets/ea6a4645-5a5d-4d1a-bbda-17730bc38660" />

- 멤버가 공유한 레포지토리 나가기 시 아래의 DB 모습처럼 Deleted_at에 시간이 들어감 
<img width="957" height="850" alt="image" src="https://github.com/user-attachments/assets/0d9aabd2-1462-41a2-b830-19d715954b2b" />
<img width="747" height="208" alt="image" src="https://github.com/user-attachments/assets/589e83f2-23b0-4595-a1f3-1ff40075d980" />

- 하지만 id 7, 9, 10처럼 재방문시 deletedAt을 null로 바꾸는 것이 아닌 아예 새로운 member를 만듬 + 환경설정 조회에서도 추방여부(deleted_at)를 보고 deletedAt이 null로만 잡혀있는 member만 잡아서 보여줌 
<img width="2114" height="1255" alt="image" src="https://github.com/user-attachments/assets/6a2fd535-c543-4188-91df-0be5627eda25" />

