### PR TITLE
fix(settings): 개인/공유된/공유받은 레포 환경설정 응답 분기처리 추가 DP-110

### DIFF
--- a/src/main/java/com/deepdirect/deepwebide_be/repository/dto/response/RepositorySettingResponse.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/repository/dto/response/RepositorySettingResponse.java
@@ -1,5 +1,6 @@
 package com.deepdirect.deepwebide_be.repository.dto.response;
 
+import com.deepdirect.deepwebide_be.repository.domain.RepositoryMemberRole;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -45,8 +46,9 @@ public class RepositorySettingResponse {
         @Schema(description = "프로필 이미지 URL")
         private String profileImageUrl;
 
-        @Schema(description = "레포 내 역할", example = "OWNER or MEMBER")
-        private String role;
+        @Schema(description = "레포 내 역할", example = "OWNER", allowableValues = {"OWNER", "MEMBER"})
+        private RepositoryMemberRole role;
     }
 
 }
+

--- a/src/main/java/com/deepdirect/deepwebide_be/repository/service/RepositoryService.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/repository/service/RepositoryService.java
@@ -308,24 +308,24 @@ public class RepositoryService {
 
         boolean isOwner = repository.getOwner().getId().equals(userId);
         boolean isMember = repositoryMemberRepository.existsByRepositoryIdAndUserIdAndDeletedAtIsNull(repositoryId, userId);
+        boolean isShared = repository.isShared();
 
         // 접근 권한 없으면 예외
-        if (!isOwner && !isMember && repository.isShared()) {
+        if (!isOwner && !isMember && isShared) {
             throw new GlobalException(ErrorCode.FORBIDDEN);
         }
 
         List<RepositorySettingResponse.MemberInfo> memberInfos = new ArrayList<>();
 
-        if (repository.isShared()) {
+        if (isShared) {
             List<RepositoryMember> members = repositoryMemberRepository.findAllByRepositoryIdAndDeletedAtIsNull(repositoryId);
             for (RepositoryMember member : members) {
                 User user = member.getUser();
-
                 memberInfos.add(RepositorySettingResponse.MemberInfo.builder()
                         .userId(user.getId())
                         .nickname(user.getNickname())
                         .profileImageUrl(user.getProfileImageUrl())
-                        .role(member.getRole().name()) // "OWNER" or "MEMBER"
+                        .role(member.getRole()) // "OWNER" or "MEMBER"
                         .build());
             }
         }
@@ -335,7 +335,7 @@ public class RepositoryService {
                 .repositoryName(repository.getRepositoryName())
                 .createdAt(repository.getCreatedAt())
                 .updatedAt(repository.getUpdatedAt())
-                .IsShared(repository.isShared())
+                .IsShared(isShared)
                 .shareLink(repository.getShareLink())
                 .members(memberInfos)
                 .build();
@@ -364,3 +364,4 @@ public class RepositoryService {
                 .anyMatch(fav -> fav.getUser().getId().equals(userId));
     }
 }
+


### PR DESCRIPTION
## 🔀 PR 제목
- [Fix] 환경설정 페이지 개인/공유한/공유된 분기처리 누락 수정

---

## 📌 작업 내용 요약
어떤 작업을 했는지 간략히 설명해주세요.

예시:
- 환경설정 페이지
  - 개인 레포 / 공유한 레포 / 공유받은 레포를 구분하지 않고 동일한 응답이 내려가는 문제 수정
- 사용자 role(OWNER, MEMBER)에 따라 응답 메시지를 분기하도록 컨트롤러 로직 추가
- role 필드를 String → RepositoryMemberRole enum 타입으로 변경하고 Swagger 문서화(@Schema) 추가

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
`Closes #이슈번호` 또는 `Related to #이슈번호` 형태로 작성

- Closes #79 
- Related to #79 
---

## 📎 기타 참고 사항
추가로 리뷰어가 참고해야 할 사항이 있다면 적어주세요.

- test 이미지가 업로드가 안돼서 공유된 notion 하단 참고 바랍니다! 
  - https://www.notion.so/239058b1ded8817eb491f85e874f260b?source=copy_link
