### PR TITLE
fix(repo):개인 레포 접근 불가 이슈 해결 - 공유 여부 상관없이 멤버이면 access 허용 DP-131

### DIFF
--- a/src/main/java/com/deepdirect/deepwebide_be/repository/service/RepositoryEntryCodeService.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/repository/service/RepositoryEntryCodeService.java
@@ -41,15 +41,10 @@ public class RepositoryEntryCodeService {
 
         RepositorySummary summary = createRepositorySummary(repository);
 
-        if (!repository.isShared() || optionalMember.isEmpty()) {
-            return RepositoryAccessCheckResponse.builder()
-                    .access(false)
-                    .repository(summary)
-                    .build();
-        }
+        boolean access = optionalMember.isPresent();
 
         return RepositoryAccessCheckResponse.builder()
-                .access(true)
+                .access(access)
                 .repository(summary)
                 .build();
     }


### PR DESCRIPTION
## 🔀 PR 제목

- [Fix] 개인 레포 접근 시 access: false 반환 문제 수정

---

## 📌 작업 내용 요약
어떤 작업을 했는지 간략히 설명해주세요.

- 기존 로직에서 !repository.isShared() 조건으로 인해 오너 접근도 막히는 문제
- 조건문을 수정하여 repositoryMember로 등록되어 있으면 access: true가 되도록 변경
---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
`Closes #이슈번호` 또는 `Related to #이슈번호` 형태로 작성

- Closes #119 
- Related to #119
---

## 📎 기타 참고 사항
추가로 리뷰어가 참고해야 할 사항이 있다면 적어주세요.

