### PR TITLE
feat(과거 채팅 조회 및 기존 채팅 조회와 병합): 과거 채팅 조회 및 기존 채팅 조회와 병합 DP-140

### DIFF
--- a/src/main/java/com/deepdirect/deepwebide_be/chat/controller/ChatController.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/chat/controller/ChatController.java
@@ -28,7 +28,10 @@ public class ChatController {
     ) {
         Long userId = userDetails.getId();
         ChatMessagesResponse response = chatMessageService.getMessages(repositoryId, userId, before, after, size);
-        return ResponseEntity.ok(ApiResponseDto.of(200, "채팅 메시지 조회에 성공했습니다.", response));
+        String message = (before != null)
+                ? "과거 채팅 메시지 조회에 성공했습니다."
+                : "채팅 메시지 조회에 성공했습니다.";
+        return ResponseEntity.ok(ApiResponseDto.of(200, message, response));
     }
 
 }

--- a/src/main/java/com/deepdirect/deepwebide_be/chat/controller/ChatController.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/chat/controller/ChatController.java
@@ -21,12 +21,13 @@ public class ChatController {
     @GetMapping("/messages")
     public ResponseEntity<ApiResponseDto<ChatMessagesResponse>> getMessages(
             @PathVariable Long repositoryId,
+            @RequestParam(required = false) Long before,
             @RequestParam(required = false) Long after,
             @RequestParam(defaultValue = "20") Integer size,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         Long userId = userDetails.getId();
-        ChatMessagesResponse response = chatMessageService.getMessages(repositoryId, userId, after, size);
+        ChatMessagesResponse response = chatMessageService.getMessages(repositoryId, userId, before, after, size);
         return ResponseEntity.ok(ApiResponseDto.of(200, "채팅 메시지 조회에 성공했습니다.", response));
     }
 

--- a/src/main/java/com/deepdirect/deepwebide_be/chat/repository/ChatMessageReferenceRepository.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/chat/repository/ChatMessageReferenceRepository.java
@@ -1,5 +1,6 @@
 package com.deepdirect.deepwebide_be.chat.repository;
 
+import com.deepdirect.deepwebide_be.chat.domain.ChatMessage;
 import com.deepdirect.deepwebide_be.chat.domain.ChatMessageReference;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,4 +9,7 @@ import java.util.List;
 public interface ChatMessageReferenceRepository extends  JpaRepository<ChatMessageReference, Long> {
     //조회된 메세지 목록 기준으로 관련된 참조 정보 한번에 조회
     List<ChatMessageReference> findByChatMessageIdIn(List<Long> chatMessageIds);
+
+    // 채팅 메시지
+    List<ChatMessageReference> findAllByChatMessage(ChatMessage chatMessage);
 }

--- a/src/main/java/com/deepdirect/deepwebide_be/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/chat/repository/ChatMessageRepository.java
@@ -14,4 +14,6 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
     // 기존 입장 (after가 있는 경우)
     List<ChatMessage> findByRepositoryIdAndIdGreaterThanOrderByIdAsc(Long repositoryId, Long after, Pageable pageable);
 
+    // 과거 메시지 조회
+    List<ChatMessage> findByRepositoryIdAndIdLessThanOrderByIdDesc(Long repositoryId, Long beforeId, Pageable pageable);
 }


### PR DESCRIPTION



## 🔀 PR 제목
- [Feature] 과거 채팅 조회 및 기존 채팅 조회와 병합

---

## 📌 작업 내용 요약
어떤 작업을 했는지 간략히 설명해주세요.

- After를 받았을 때와 Before를 받았을 때 다르게 받아서
- 각 요청한 Param값에 맞게 보여줌
- 조회한 사용자 기준으로 본인이 보낸건지 아닌지 확인 가능
- 스크롤을 위해 기존 사이즈(20)보다 양이 더 남았는지 확인 가능
---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [ ] 기능 요구사항을 모두 구현했나요?
- [ ] 로컬에서 기능을 직접 테스트했나요?
- [ ] 코드 컨벤션 및 스타일을 지켰나요?
- [ ] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
`Closes #이슈번호` 또는 `Related to #이슈번호` 형태로 작성

예시:
- Closes #129 
- Related to #129 

---

## 📎 기타 참고 사항
추가로 리뷰어가 참고해야 할 사항이 있다면 적어주세요.


-테스트 결과는 아래 노션  페이지 결과 참조
https://www.notion.so/23e058b1ded8806bb7a7f924370a6a58?source=copy_link
