### PR TITLE
Feature/dp 137 chat session

### DIFF
--- a/src/main/java/com/deepdirect/deepwebide_be/chat/domain/ChatMessageReference.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/chat/domain/ChatMessageReference.java
@@ -20,8 +20,8 @@ public class ChatMessageReference {
     @JoinColumn(name = "chat_message_id", nullable = false)
     private ChatMessage chatMessage;
 
-    @Column(name = "file_path", nullable = false)
-    private String filePath;
+    @Column(name = "path", nullable = false)
+    private String path;
 
     @Column(name = "line_number")
     private Integer lineNumber;

--- a/src/main/java/com/deepdirect/deepwebide_be/chat/dto/response/ChatUserEventResponse.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/chat/dto/response/ChatUserEventResponse.java
@@ -1,0 +1,31 @@
+package com.deepdirect.deepwebide_be.chat.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@Schema(description = "채팅방 사용자 입퇴장 메시지 응답")
+public class ChatUserEventResponse {
+
+    @Schema(description = "이벤트 타입", example = "USER_JOINED or USER_LEFT")
+    private String type;
+
+    @Schema(description = "레포지토리 ID")
+    private Long repositoryId;
+
+    @Schema(description = "사용자 정보")
+    private ChatUserInfoResponse user;
+
+    @Schema(description = "현재 접속자 수")
+    private int activeUserCount;
+
+    @Schema(description = "메시지")
+    private String message;
+
+    @Schema(description = "이벤트 발생 시간", example = "2025-07-28T12:05:00Z")
+    private LocalDateTime timestamp;
+}

--- a/src/main/java/com/deepdirect/deepwebide_be/chat/dto/response/ChatUserInfoResponse.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/chat/dto/response/ChatUserInfoResponse.java
@@ -1,0 +1,17 @@
+package com.deepdirect.deepwebide_be.chat.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "채팅방 사용자 정보 응답")
+public class ChatUserInfoResponse {
+
+    @Schema(description = "사용자 ID")
+    private Long userId;
+
+    @Schema(description = "닉네임")
+    private String nickname;
+}

--- a/src/main/java/com/deepdirect/deepwebide_be/chat/dto/response/CodeReferenceResponse.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/chat/dto/response/CodeReferenceResponse.java
@@ -14,7 +14,7 @@ public class CodeReferenceResponse {
     private final Long referenceId;
 
     @Schema(description = "파일 경로")
-    private final String filePath;
+    private final String path;
 
     @Schema(description = "라인 번호", nullable = true)
     private final Integer line;
@@ -22,7 +22,7 @@ public class CodeReferenceResponse {
     public static CodeReferenceResponse from(ChatMessageReference ref) {
         return CodeReferenceResponse.builder()
                 .referenceId(ref.getId())
-                .filePath(ref.getFilePath())
+                .path(ref.getPath())
                 .line(ref.getLineNumber())
                 .build();
     }

--- a/src/main/java/com/deepdirect/deepwebide_be/chat/service/ChatSessionService.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/chat/service/ChatSessionService.java
@@ -1,49 +1,120 @@
 package com.deepdirect.deepwebide_be.chat.service;
 
+import com.deepdirect.deepwebide_be.chat.dto.response.ChatUserEventResponse;
+import com.deepdirect.deepwebide_be.chat.dto.response.ChatUserInfoResponse;
+import com.deepdirect.deepwebide_be.global.exception.ErrorCode;
+import com.deepdirect.deepwebide_be.global.exception.GlobalException;
+import com.deepdirect.deepwebide_be.member.domain.User;
+import com.deepdirect.deepwebide_be.member.repository.UserRepository;
+import com.deepdirect.deepwebide_be.repository.domain.Repository;
+import com.deepdirect.deepwebide_be.repository.repository.RepositoryRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class ChatSessionService {
 
     private final StringRedisTemplate redisTemplate;
+    private final SimpMessagingTemplate messagingTemplate;
+    private final UserRepository userRepository;
+    private final RepositoryRepository repositoryRepository;
 
-    private static final String SESSION_KEY_PREFIX = "chat_session:"; // 세션 사용자 목록
-    private static final String SESSION_MAPPING_PREFIX = "session_mapping:"; // sessionId → repositoryId:userId
+    private static final String SESSION_KEY_PREFIX = "chat_session:";
+    private static final String SESSION_META_PREFIX = "chat_session_meta:";
 
     public void addSession(Long repositoryId, Long userId, String sessionId) {
-        // 사용자 등록
-        String repoKey = SESSION_KEY_PREFIX + repositoryId;
-        redisTemplate.opsForSet().add(repoKey, String.valueOf(userId));
+        Repository repository = repositoryRepository.findByIdAndDeletedAtIsNull(repositoryId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.REPOSITORY_NOT_FOUND));
 
-        // sessionId -> repoId:userId 매핑
-        String mappingKey = SESSION_MAPPING_PREFIX + sessionId;
-        String mappingValue = repositoryId + ":" + userId;
-        redisTemplate.opsForValue().set(mappingKey, mappingValue);
+        // 공유되지 않은 레포 차단
+        if (!repository.isShared()) {
+            throw new GlobalException(ErrorCode.REPOSITORY_NOT_SHARED);
+        }
+
+        // Redis에 세션 저장 (세트에 sessionId 저장)
+        redisTemplate.opsForSet().add(getSessionKey(repositoryId), sessionId);
+        redisTemplate.opsForHash().put(getSessionMetaKey(sessionId), "repositoryId", repositoryId.toString());
+        redisTemplate.opsForHash().put(getSessionMetaKey(sessionId), "userId", userId.toString());
+
+        // 접속자 수 조회
+        Long activeCount = redisTemplate.opsForSet().size(getSessionKey(repositoryId));
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
+
+        // 메시지 브로드캐스트
+        ChatUserEventResponse message = ChatUserEventResponse.builder()
+                .type("USER_JOINED")
+                .repositoryId(repositoryId)
+                .user(ChatUserInfoResponse.builder()
+                        .userId(user.getId())
+                        .nickname(user.getNickname())
+                        .build())
+                .activeUserCount(activeCount.intValue())
+                .message("입장에 성공하였습니다.")
+                .timestamp(LocalDateTime.now())
+                .build();
+
+        messagingTemplate.convertAndSend(
+                "/topic/repositories/" + repositoryId + "/chat", message
+        );
+
+        log.info("USER_JOINED 전송: repositoryId={}, userId={}, sessionId={}", repositoryId, userId, sessionId);
     }
 
     public void removeSessionBySessionId(String sessionId) {
-        String mappingKey = SESSION_MAPPING_PREFIX + sessionId;
-        String value = redisTemplate.opsForValue().get(mappingKey);
+        String metaKey = getSessionMetaKey(sessionId);
 
-        if (value != null && value.contains(":")) {
-            String[] parts = value.split(":");
-            Long repositoryId = Long.parseLong(parts[0]);
-            Long userId = Long.parseLong(parts[1]);
+        String repositoryIdStr = (String) redisTemplate.opsForHash().get(metaKey, "repositoryId");
+        String userIdStr = (String) redisTemplate.opsForHash().get(metaKey, "userId");
 
-            // 사용자 제거
-            String repoKey = SESSION_KEY_PREFIX + repositoryId;
-            redisTemplate.opsForSet().remove(repoKey, String.valueOf(userId));
+        if (repositoryIdStr == null || userIdStr == null) {
+            log.warn("세션 메타 정보 누락: sessionId={}", sessionId);
+            return;
         }
 
-        // 세션 매핑 삭제
-        redisTemplate.delete(mappingKey);
+        Long repositoryId = Long.parseLong(repositoryIdStr);
+        Long userId = Long.parseLong(userIdStr);
+
+        // Redis에서 세션 제거
+        redisTemplate.opsForSet().remove(getSessionKey(repositoryId), sessionId);
+        redisTemplate.delete(metaKey);
+
+        Long activeCount = redisTemplate.opsForSet().size(getSessionKey(repositoryId));
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
+
+        // 메시지 브로드캐스트
+        ChatUserEventResponse message = ChatUserEventResponse.builder()
+                .type("USER_LEFT")
+                .repositoryId(repositoryId)
+                .user(ChatUserInfoResponse.builder()
+                        .userId(user.getId())
+                        .nickname(user.getNickname())
+                        .build())
+                .activeUserCount(activeCount.intValue())
+                .message("퇴장에 성공하였습니다.")
+                .timestamp(LocalDateTime.now())
+                .build();
+
+        messagingTemplate.convertAndSend(
+                "/topic/repositories/" + repositoryId + "/chat", message
+        );
+
+        log.info("USER_LEFT 전송: repositoryId={}, userId={}, sessionId={}", repositoryId, userId, sessionId);
     }
 
-    public Long getSessionCount(Long repositoryId) {
-        String key = SESSION_KEY_PREFIX + repositoryId;
-        return redisTemplate.opsForSet().size(key);
+    private String getSessionKey(Long repositoryId) {
+        return SESSION_KEY_PREFIX + repositoryId;
+    }
+
+    private String getSessionMetaKey(String sessionId) {
+        return SESSION_META_PREFIX + sessionId;
     }
 }
-

--- a/src/main/java/com/deepdirect/deepwebide_be/chat/service/ChatSessionService.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/chat/service/ChatSessionService.java
@@ -1,0 +1,49 @@
+package com.deepdirect.deepwebide_be.chat.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+@Service
+@RequiredArgsConstructor
+public class ChatSessionService {
+
+    private final StringRedisTemplate redisTemplate;
+
+    private static final String SESSION_KEY_PREFIX = "chat_session:"; // 세션 사용자 목록
+    private static final String SESSION_MAPPING_PREFIX = "session_mapping:"; // sessionId → repositoryId:userId
+
+    public void addSession(Long repositoryId, Long userId, String sessionId) {
+        // 사용자 등록
+        String repoKey = SESSION_KEY_PREFIX + repositoryId;
+        redisTemplate.opsForSet().add(repoKey, String.valueOf(userId));
+
+        // sessionId -> repoId:userId 매핑
+        String mappingKey = SESSION_MAPPING_PREFIX + sessionId;
+        String mappingValue = repositoryId + ":" + userId;
+        redisTemplate.opsForValue().set(mappingKey, mappingValue);
+    }
+
+    public void removeSessionBySessionId(String sessionId) {
+        String mappingKey = SESSION_MAPPING_PREFIX + sessionId;
+        String value = redisTemplate.opsForValue().get(mappingKey);
+
+        if (value != null && value.contains(":")) {
+            String[] parts = value.split(":");
+            Long repositoryId = Long.parseLong(parts[0]);
+            Long userId = Long.parseLong(parts[1]);
+
+            // 사용자 제거
+            String repoKey = SESSION_KEY_PREFIX + repositoryId;
+            redisTemplate.opsForSet().remove(repoKey, String.valueOf(userId));
+        }
+
+        // 세션 매핑 삭제
+        redisTemplate.delete(mappingKey);
+    }
+
+    public Long getSessionCount(Long repositoryId) {
+        String key = SESSION_KEY_PREFIX + repositoryId;
+        return redisTemplate.opsForSet().size(key);
+    }
+}
+

--- a/src/main/java/com/deepdirect/deepwebide_be/chat/websocket/WebSocketEventListener.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/chat/websocket/WebSocketEventListener.java
@@ -1,0 +1,55 @@
+package com.deepdirect.deepwebide_be.chat.websocket;
+
+import com.deepdirect.deepwebide_be.chat.service.ChatSessionService;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionConnectEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+@Component
+@RequiredArgsConstructor
+public class WebSocketEventListener {
+
+    private static final Logger log = LoggerFactory.getLogger(WebSocketEventListener.class);
+    private final ChatSessionService chatSessionService;
+
+    @EventListener
+    public void handleSessionConnected(SessionConnectEvent event) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+        String sessionId = accessor.getSessionId();
+        String repositoryIdHeader = accessor.getFirstNativeHeader("repositoryId");
+        String userIdHeader = accessor.getFirstNativeHeader("userId");
+
+        if (repositoryIdHeader == null || userIdHeader == null || sessionId == null) {
+            log.warn("WebSocket 접속 시 헤더 누락 (repositoryId: {}, userId: {}, sessionId: {})",
+                    repositoryIdHeader, userIdHeader, sessionId);
+            return;
+        }
+
+        try {
+            Long repositoryId = Long.parseLong(repositoryIdHeader);
+            Long userId = Long.parseLong(userIdHeader);
+            chatSessionService.addSession(repositoryId, userId, sessionId);
+            log.info("✅ WebSocket 연결됨: repositoryId={}, userId={}, sessionId={}", repositoryId, userId, sessionId);
+        } catch (NumberFormatException e) {
+            log.warn("WebSocket 연결 시 잘못된 헤더 형식 (repositoryId: {}, userId: {})", repositoryIdHeader, userIdHeader);
+        }
+    }
+
+    @EventListener
+    public void handleSessionDisconnected(SessionDisconnectEvent event) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+        String sessionId = accessor.getSessionId();
+
+        if (sessionId != null) {
+            chatSessionService.removeSessionBySessionId(sessionId);
+            log.info("WebSocket 연결 종료: sessionId={}", sessionId);
+        } else {
+            log.warn("WebSocket 연결 종료 시 sessionId 누락");
+        }
+    }
+}

--- a/src/main/java/com/deepdirect/deepwebide_be/global/config/WebSocketConfig.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/global/config/WebSocketConfig.java
@@ -1,0 +1,24 @@
+package com.deepdirect.deepwebide_be.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws/chat") // 프론트가 연결할 엔드포인트
+                .setAllowedOriginPatterns("*") // CORS 허용 (배포시 보안 고려 필요)
+                .withSockJS(); // SockJS fallback
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/topic"); // 메시지 수신 구독용 prefix
+        registry.setApplicationDestinationPrefixes("/app"); // 메시지 발신용 prefix
+    }
+}

--- a/src/main/java/com/deepdirect/deepwebide_be/global/security/SecurityConfiguration.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/global/security/SecurityConfiguration.java
@@ -88,7 +88,8 @@ public class SecurityConfiguration {
                                 new AntPathRequestMatcher("/api/auth/**"),
                                 new AntPathRequestMatcher("/h2-console/**"),
                                 new AntPathRequestMatcher("/redis-test"),
-                                new AntPathRequestMatcher("/test/**") // Sentry 테스트용
+                                new AntPathRequestMatcher("/test/**"), // Sentry 테스트용
+                                new AntPathRequestMatcher("/ws/**")
                         ).permitAll()
                         .requestMatchers(new AntPathRequestMatcher("/api/auth/signout")).authenticated()
                         .anyRequest().authenticated()


### PR DESCRIPTION
## 🔀 PR 제목
- [Feature] 채팅방 입장/퇴장 세션 관리 기능 구현

---

## 📌 작업 내용 요약
어떤 작업을 했는지 간략히 설명해주세요.

- WebSocket 연결 시 `ChatSessionService`를 통해 Redis에 사용자 세션 저장
- 연결 해제 시 Redis에서 세션 제거
- `WebSocketEventListener`를 통해 STOMP 연결/해제 이벤트 감지
- 입퇴장 이벤트를 /topic/repositories/{repositoryId}/chat
- 입장/퇴장 사용자 정보를 위한 응답 DTO 정의
- Postman WebSocket Client로 테스트 완료

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
`Closes #이슈번호` 또는 `Related to #이슈번호` 형태로 작성

예시:
- Closes #126 
- Related to #126 
---

## 📎 기타 참고 사항
추가로 리뷰어가 참고해야 할 사항이 있다면 적어주세요.

예시:
- API 명세 변경사항 포함됨
- 테스트 코드는 다음 PR에서 작성 예정
