### PR TITLE
fix(즐겨찾기 필터링 시 페이징과 즐겨찾기 여부 순서): 즐겨찾기 필터링 시 페이징과 즐겨찾기 여부 순서 DP-151

### DIFF
--- a/src/main/java/com/deepdirect/deepwebide_be/repository/service/RepositoryService.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/repository/service/RepositoryService.java
@@ -20,6 +20,7 @@ import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -83,79 +84,103 @@ public class RepositoryService {
                 .build();
     }
 
-    public RepositoryListResponse getSharedRepositories(Long userId, Pageable pageable, Boolean liked) {
-        Pageable sortedPageable = getSortedPageable(pageable);
-
-        Page<Repository> repositoryPage = repositoryRepository
-                .findByIsSharedTrueAndDeletedAtIsNullAndOwnerId(userId, sortedPageable);
+    public RepositoryListResponse getMyRepositories(Long userId, Pageable pageable, Boolean liked) {
+        List<Repository> repositories = repositoryRepository
+                .findByOwnerIdAndIsSharedFalseAndDeletedAtIsNull(userId, Pageable.unpaged())
+                .getContent();
 
         List<Repository> filtered = Boolean.TRUE.equals(liked)
-                ? repositoryPage.stream()
+                ? repositories.stream()
                 .filter(repo -> isFavoriteByUser(repo, userId))
                 .toList()
-                : repositoryPage.getContent();
+                : repositories;
 
-        List<RepositoryResponse> sharedRepositoryDtos = filtered.stream()
+        List<Repository> sorted = filtered.stream()
+                .sorted(Comparator.comparing(Repository::getUpdatedAt).reversed()
+                        .thenComparing(Repository::getRepositoryName))
+                .toList();
+
+        int start = (int) pageable.getOffset();
+        int end = Math.min(start + pageable.getPageSize(), sorted.size());
+        List<RepositoryResponse> pagedList = sorted.subList(start, end).stream()
                 .map(repo -> RepositoryResponse.from(repo, isFavoriteByUser(repo, userId)))
                 .toList();
 
+        int totalPages = (int) Math.ceil((double) sorted.size() / pageable.getPageSize());
+
         return RepositoryListResponse.builder()
-                .currentPage(repositoryPage.getNumber())
-                .pageSize(repositoryPage.getSize())
-                .totalPages(repositoryPage.getTotalPages())
-                .totalElements(repositoryPage.getTotalElements())
-                .repositories(sharedRepositoryDtos)
+                .currentPage(pageable.getPageNumber())
+                .pageSize(pageable.getPageSize())
+                .totalPages(totalPages)
+                .totalElements(sorted.size())
+                .repositories(pagedList)
+                .build();
+    }
+
+    public RepositoryListResponse getSharedRepositories(Long userId, Pageable pageable, Boolean liked) {
+        List<Repository> repositories = repositoryRepository
+                .findByIsSharedTrueAndDeletedAtIsNullAndOwnerId(userId, Pageable.unpaged())
+                .getContent();
+
+        List<Repository> filtered = Boolean.TRUE.equals(liked)
+                ? repositories.stream()
+                .filter(repo -> isFavoriteByUser(repo, userId))
+                .toList()
+                : repositories;
+
+        List<Repository> sorted = filtered.stream()
+                .sorted(Comparator.comparing(Repository::getUpdatedAt).reversed()
+                        .thenComparing(Repository::getRepositoryName))
+                .toList();
+
+        int start = (int) pageable.getOffset();
+        int end = Math.min(start + pageable.getPageSize(), sorted.size());
+        List<RepositoryResponse> pagedList = sorted.subList(start, end).stream()
+                .map(repo -> RepositoryResponse.from(repo, isFavoriteByUser(repo, userId)))
+                .toList();
+
+        int totalPages = (int) Math.ceil((double) sorted.size() / pageable.getPageSize());
+
+        return RepositoryListResponse.builder()
+                .currentPage(pageable.getPageNumber())
+                .pageSize(pageable.getPageSize())
+                .totalPages(totalPages)
+                .totalElements(sorted.size())
+                .repositories(pagedList)
                 .build();
     }
 
     public RepositoryListResponse getReceivedSharedRepositories(Long userId, Pageable pageable, Boolean liked) {
-        Pageable sortedPageable = getSortedPageable(pageable);
-
-        Page<Repository> repositoryPage = repositoryRepository
+        List<Repository> repositories = repositoryRepository
                 .findByMembersUserIdAndMembersRoleAndIsSharedTrueAndDeletedAtIsNullAndMembersDeletedAtIsNull(
-                        userId, RepositoryMemberRole.MEMBER, sortedPageable);
+                        userId, RepositoryMemberRole.MEMBER, Pageable.unpaged())
+                .getContent();
 
         List<Repository> filtered = Boolean.TRUE.equals(liked)
-                ? repositoryPage.stream()
+                ? repositories.stream()
                 .filter(repo -> isFavoriteByUser(repo, userId))
                 .toList()
-                : repositoryPage.getContent();
+                : repositories;
 
-        List<RepositoryResponse> sharedRepositoryDtos = filtered.stream()
+        List<Repository> sorted = filtered.stream()
+                .sorted(Comparator.comparing(Repository::getUpdatedAt).reversed()
+                        .thenComparing(Repository::getRepositoryName))
+                .toList();
+
+        int start = (int) pageable.getOffset();
+        int end = Math.min(start + pageable.getPageSize(), sorted.size());
+        List<RepositoryResponse> pagedList = sorted.subList(start, end).stream()
                 .map(repo -> RepositoryResponse.from(repo, isFavoriteByUser(repo, userId)))
                 .toList();
 
-        return RepositoryListResponse.builder()
-                .currentPage(repositoryPage.getNumber())
-                .pageSize(repositoryPage.getSize())
-                .totalPages(repositoryPage.getTotalPages())
-                .totalElements(repositoryPage.getTotalElements())
-                .repositories(sharedRepositoryDtos)
-                .build();
-    }
-
-    public RepositoryListResponse getMyRepositories(Long userId, Pageable pageable, Boolean liked) {
-        Pageable sortedPageable = getSortedPageable(pageable);
-
-        Page<Repository> repositoryPage = repositoryRepository
-                .findByOwnerIdAndIsSharedFalseAndDeletedAtIsNull(userId, sortedPageable);
-
-        List<Repository> filtered = Boolean.TRUE.equals(liked)
-                ? repositoryPage.stream()
-                .filter(repo -> isFavoriteByUser(repo, userId))
-                .toList()
-                : repositoryPage.getContent();
-
-        List<RepositoryResponse> sharedRepositoryDtos = filtered.stream()
-                .map(repo -> RepositoryResponse.from(repo, isFavoriteByUser(repo, userId)))
-                .toList();
+        int totalPages = (int) Math.ceil((double) sorted.size() / pageable.getPageSize());
 
         return RepositoryListResponse.builder()
-                .currentPage(repositoryPage.getNumber())
-                .pageSize(repositoryPage.getSize())
-                .totalPages(repositoryPage.getTotalPages())
-                .totalElements(repositoryPage.getTotalElements())
-                .repositories(sharedRepositoryDtos)
+                .currentPage(pageable.getPageNumber())
+                .pageSize(pageable.getPageSize())
+                .totalPages(totalPages)
+                .totalElements(sorted.size())
+                .repositories(pagedList)
                 .build();
     }
 


### PR DESCRIPTION



## 🔀 PR 제목
- [Fix] 즐겨찾기 필터링 시 페이징과 즐겨찾기 여부 순서

---

## 📌 작업 내용 요약
어떤 작업을 했는지 간략히 설명해주세요.

- 즐겨찾기 여부 전에 페이징 먼저 진행하면서 레포가 원래 있던 페이지에서 필터링 되는 상황 발생
- 즐겨찾기 여부 먼저 필터링 후에 그에 맞게 다시 페이지네이션을 진행(7개를 기준으로 다시 계산해서 보여줌)

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [ ] 기능 요구사항을 모두 구현했나요?
- [ ] 로컬에서 기능을 직접 테스트했나요?
- [ ] 코드 컨벤션 및 스타일을 지켰나요?
- [ ] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
`Closes #이슈번호` 또는 `Related to #이슈번호` 형태로 작성

예시:
- Closes #148 
- Related to #148 
---

## 📎 기타 참고 사항
추가로 리뷰어가 참고해야 할 사항이 있다면 적어주세요.

- 트러블 슈팅 및 테스트 결과 
https://www.notion.so/2-2-23f058b1ded880af90fbcf5b0c3db748?source=copy_link
