### PR TITLE
fix(코드참조 경로 조회시 파일만 조회): 코드참조 경로 조회시 파일만 조회 DP-172

### DIFF
--- a/src/main/java/com/deepdirect/deepwebide_be/chat/service/ChatMessageService.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/chat/service/ChatMessageService.java
@@ -10,6 +10,7 @@ import com.deepdirect.deepwebide_be.chat.dto.response.CodeReferenceResponse;
 import com.deepdirect.deepwebide_be.chat.repository.ChatMessageReferenceRepository;
 import com.deepdirect.deepwebide_be.chat.repository.ChatMessageRepository;
 import com.deepdirect.deepwebide_be.file.domain.FileNode;
+import com.deepdirect.deepwebide_be.file.domain.FileType;
 import com.deepdirect.deepwebide_be.file.repository.FileNodeRepository;
 import com.deepdirect.deepwebide_be.global.exception.ErrorCode;
 import com.deepdirect.deepwebide_be.global.exception.GlobalException;
@@ -164,15 +165,9 @@ public class ChatMessageService {
         List<FileNode> fileNodes = fileNodeRepository.findAllByRepositoryId(repositoryId);
 
         List<String> paths = fileNodes.stream()
+                .filter(node -> node.getFileType() == FileType.FILE) // ← 폴더는 제외
                 .map(FileNode::getPath)
-                .sorted((a, b) -> {
-                    // 폴더 먼저, 사전순 정렬
-                    boolean isAFolder = a.endsWith("/");
-                    boolean isBFolder = b.endsWith("/");
-                    if (isAFolder && !isBFolder) return -1;
-                    if (!isAFolder && isBFolder) return 1;
-                    return a.compareToIgnoreCase(b);
-                })
+                .sorted(String::compareToIgnoreCase)
                 .toList();
 
         return CodePathListResponse.builder().paths(paths).build();


### PR DESCRIPTION


## 🔀 PR 제목

- [Fix] 코드 참조 경로 조회시 파일만 조회  

---

## 📌 작업 내용 요약
어떤 작업을 했는지 간략히 설명해주세요.

- FileType을 보고 FILE인 것만 조회되도록 수정


---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [ ] 기능 요구사항을 모두 구현했나요?
- [ ] 로컬에서 기능을 직접 테스트했나요?
- [ ] 코드 컨벤션 및 스타일을 지켰나요?
- [ ] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
`Closes #이슈번호` 또는 `Related to #이슈번호` 형태로 작성


- Closes #172 
- Related to #172 
---

## 📎 기타 참고 사항
추가로 리뷰어가 참고해야 할 사항이 있다면 적어주세요.

- QA 페이지 참조 
- https://www.notion.so/API-240058b1ded8801cb96ada99c2649554?source=copy_link
