### PR TITLE
feat(history): 히스토리 저장 로직 변경 DP-169

### DIFF
--- a/src/main/java/com/deepdirect/deepwebide_be/file/repository/FileContentRepository.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/file/repository/FileContentRepository.java
@@ -3,7 +3,10 @@ package com.deepdirect.deepwebide_be.file.repository;
 import com.deepdirect.deepwebide_be.file.domain.FileContent;
 import com.deepdirect.deepwebide_be.file.domain.FileNode;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface FileContentRepository extends JpaRepository<FileContent, Long> {
@@ -12,4 +15,6 @@ public interface FileContentRepository extends JpaRepository<FileContent, Long> 
 
     Optional<FileContent> findByFileNode(FileNode fileNode);
 
+    @Query("SELECT fc FROM FileContent fc WHERE fc.fileNode.repository.id = :repositoryId")
+    List<FileContent> findAllByRepositoryId(@Param("repositoryId") Long repositoryId);
 }

--- a/src/main/java/com/deepdirect/deepwebide_be/history/dto/request/HistorySaveRequest.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/history/dto/request/HistorySaveRequest.java
@@ -14,33 +14,4 @@ public class HistorySaveRequest {
     @Schema(description = "저장 메시지(커밋 메시지)", example = "1차 개발 완료")
     private String message;
 
-    @Schema(description = "저장할 파일/폴더 노드 목록 (트리 구조 아님, 전체 파일/폴더의 납작한 배열)")
-    private List<NodeDto> nodes;
-
-    @Getter
-    @NoArgsConstructor
-    @Schema(description = "파일 또는 폴더 노드 정보")
-    public static class NodeDto {
-
-        @Schema(description = "파일/폴더 ID (생성 직후는 null일 수 있음, 기존 파일은 PK)",
-                example = "4")
-        private Long fileId;
-
-        @Schema(description = "파일/폴더명", example = "Main.java")
-        private String fileName;
-
-        @Schema(description = "노드 타입 (FILE: 파일, FOLDER: 폴더)", example = "FILE")
-        private String fileType;
-
-        @Schema(description = "부모 폴더 ID (최상위면 null)", example = "1")
-        private Long parentId;
-
-        @Schema(description = "파일/폴더 전체 경로", example = "src/Main.java")
-        private String path;
-
-        @Schema(description = "파일 내용 (파일일 때만 존재, 폴더면 null)",
-                example = "public class Main { ... }",
-                nullable = true)
-        private String content;
-    }
 }


### PR DESCRIPTION
## 🔀 PR 제목

- [Fix] 히스토리 저장 로직 변경

---

## 📌 작업 내용 요약

- 기존 프론트엔드에서 모든 파일 노드 및 콘텐츠를 받던 구조에서
- 단순히 현 시점 최신 저장본을 저장 하는 방식으로 변경

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [ ] 기능 요구사항을 모두 구현했나요?
- [ ] 로컬에서 기능을 직접 테스트했나요?
- [ ] 코드 컨벤션 및 스타일을 지켰나요?
- [ ] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

- Closes #169

---

