### PR TITLE
fix(비밀번호 글자수 에러 메시지 추가): 비밀번호 글자수 에러 메시지 추가 DP-175

### DIFF
--- a/src/main/java/com/deepdirect/deepwebide_be/global/exception/ErrorCode.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/global/exception/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
     REPOSITORY_MEMBER_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "최대 인원이 초과되어 입장할 수 없습니다."),
     INVALID_USERNAME(HttpStatus.BAD_REQUEST, "이름은 한글 2자 이상만 입력 가능합니다."),
     INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "비밀번호는 영어 대문자, 소문자, 숫자, 특수문자를 모두 포함해야 합니다."),
+    PASSWORD_TOO_SHORT(HttpStatus.BAD_REQUEST,"비밀번호는 8자 이상이어야 합니다."),
     VERIFICATION_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "인증번호가 만료되었습니다."),
     NOT_OWNER_CHANGE(HttpStatus.BAD_REQUEST, "오너만 이름을 변경할 수 있습니다."), //오너만 이름 변경!!
     NOT_OWNER_DELETE(HttpStatus.BAD_REQUEST, "오너만 삭제할 수 있습니다."), //오너만 삭제 가능

--- a/src/main/java/com/deepdirect/deepwebide_be/member/service/UserService.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/member/service/UserService.java
@@ -75,6 +75,10 @@ public class UserService {
             throw new GlobalException(ErrorCode.PASSWORDS_DO_NOT_MATCH);
         }
 
+        if (request.getPassword().length() < 8) {
+            throw new GlobalException(ErrorCode.PASSWORD_TOO_SHORT);
+        }
+
         if (!PASSWORD_REGEX.matcher(request.getPassword()).matches()) {
             throw new GlobalException(ErrorCode.INVALID_PASSWORD_FORMAT);
         }


### PR DESCRIPTION
## 🔀 PR 제목
- [Feature] 로그인 기능 구현  
- [Fix] 비밀번호 글자수 에러 메시지 추가  
- [Refactor] 로그인 UI 코드 개선  

---

## 📌 작업 내용 요약
어떤 작업을 했는지 간략히 설명해주세요.

- 회원가입 비밀번호 설정 시 8자 미만으로 가면 포맷에러코드가 나옴
- 비밀번호가 8자 이상인지 먼저 확인하도록 로직 추가 + 에러 메시지 추가

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [ ] 기능 요구사항을 모두 구현했나요?
- [ ] 로컬에서 기능을 직접 테스트했나요?
- [ ] 코드 컨벤션 및 스타일을 지켰나요?
- [ ] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
`Closes #이슈번호` 또는 `Related to #이슈번호` 형태로 작성

예시:
- Closes #179 
- Related to #179 
---

## 📎 기타 참고 사항
추가로 리뷰어가 참고해야 할 사항이 있다면 적어주세요.

- 테스트 참고 
- https://www.notion.so/API-240058b1ded880e1a297f7d0da4675fa?source=copy_link