### PR TITLE
[Fix] 로그인 시 이메일 인증 여부 확인 및 미인증 시 재인증 메일 발송 로직 구현

### DIFF
--- a/src/main/java/com/deepdirect/deepwebide_be/global/exception/ErrorCode.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/global/exception/ErrorCode.java
@@ -49,6 +49,7 @@ public enum ErrorCode {
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
     MISSING_TOKEN(HttpStatus.UNAUTHORIZED, "Access Token이 누락되었습니다."),
     EMAIL_NOT_VERIFIED(HttpStatus.UNAUTHORIZED, "이메일 인증이 완료되지 않았습니다."),
+    EMAIL_NOT_VERIFIED_CODE_RESENT(HttpStatus.UNAUTHORIZED, "인증 코드가 만료되어 새로운 인증 이메일을 발송했습니다."),
 
 
     // 403 FORBIDDEN

--- a/src/main/java/com/deepdirect/deepwebide_be/global/exception/ErrorCode.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/global/exception/ErrorCode.java
@@ -48,6 +48,8 @@ public enum ErrorCode {
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
     MISSING_TOKEN(HttpStatus.UNAUTHORIZED, "Access Token이 누락되었습니다."),
+    EMAIL_NOT_VERIFIED(HttpStatus.UNAUTHORIZED, "이메일 인증이 완료되지 않았습니다."),
+
 
     // 403 FORBIDDEN
     FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),

--- a/src/main/java/com/deepdirect/deepwebide_be/member/domain/EmailVerification.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/member/domain/EmailVerification.java
@@ -21,7 +21,7 @@ public class EmailVerification {
     @Column(nullable = false)
     private String emailCode;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private String email;
 
     @Column(nullable = false)

--- a/src/main/java/com/deepdirect/deepwebide_be/member/repository/EmailVerificationRepository.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/member/repository/EmailVerificationRepository.java
@@ -1,6 +1,7 @@
 package com.deepdirect.deepwebide_be.member.repository;
 
 import com.deepdirect.deepwebide_be.member.domain.EmailVerification;
+import org.springframework.data.domain.Limit;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -10,4 +11,6 @@ public interface EmailVerificationRepository extends JpaRepository<EmailVerifica
     // 이메일 인증 코드 조회
     Optional<EmailVerification> findByEmailCode(String code);
 
+
+    Optional<EmailVerification> findTopByEmailOrderByCreatedAtDesc(String email);
 }

--- a/src/main/java/com/deepdirect/deepwebide_be/member/service/UserService.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/member/service/UserService.java
@@ -117,6 +117,10 @@ public class UserService {
         User user = userRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new GlobalException(ErrorCode.WRONG_PASSWORD));
 
+        if (!user.isEmailVerified()) {
+            throw new GlobalException(ErrorCode.EMAIL_NOT_VERIFIED);
+        }
+
         if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
             throw new GlobalException(ErrorCode.WRONG_PASSWORD);
         }

--- a/src/main/java/com/deepdirect/deepwebide_be/member/service/UserService.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/member/service/UserService.java
@@ -118,7 +118,7 @@ public class UserService {
                 .orElseThrow(() -> new GlobalException(ErrorCode.WRONG_PASSWORD));
 
         if (!user.isEmailVerified()) {
-            throw new GlobalException(ErrorCode.EMAIL_NOT_VERIFIED);
+            emailVerificationService.handleEmailVerification(user.getEmail());
         }
 
         if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {


### PR DESCRIPTION
## 🔀 PR 제목
[Fix] 로그인 시 이메일 인증 여부 확인 및 미인증 시 재인증 메일 발송 로직 구현

---

## 📌 작업 내용 요약
- 이메일 인증 여부 확인 → handleEmailVerification에서 인증 코드 유효한지 확인 → 새로운 인증 코드 발송 또는 유효하다는 내용의 에러 반환

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
Closes #178

---

## 📎 기타 참고 사항
  <img width="656" height="86" alt="image" src="https://github.com/user-attachments/assets/a7025278-355a-4fc5-9d08-4003ee3ab7f0" />
  <img width="545" height="536" alt="image" src="https://github.com/user-attachments/assets/cb4a346b-9fe6-4185-9642-8b601252c35d" />

