### PR TITLE
Fix/dp 178 chat 관련 오류 수정

### DIFF
--- a/src/main/java/com/deepdirect/deepwebide_be/chat/controller/ChatWebSocketController.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/chat/controller/ChatWebSocketController.java
@@ -38,6 +38,6 @@ public class ChatWebSocketController {
         ChatMessageBroadcast broadcast = chatMessageWriteService.saveChatMessage(userId, request);
 
         // 3. Redis 채널로 publish
-        redisPublisher.publish("chatroom:" + request.getRepositoryId(), broadcast);
+        redisPublisher.publish("chat:" + request.getRepositoryId(), broadcast);
     }
 }

--- a/src/main/java/com/deepdirect/deepwebide_be/chat/dto/response/ChatMessageBroadcast.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/chat/dto/response/ChatMessageBroadcast.java
@@ -5,7 +5,6 @@ import com.deepdirect.deepwebide_be.chat.domain.ChatMessageType;
 import com.deepdirect.deepwebide_be.member.domain.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
-import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 
@@ -41,8 +40,8 @@ public class ChatMessageBroadcast {
     @Schema(description = "보낸 시간")
     private LocalDateTime sentAt;
 
-    @Schema(description = "내 메시지 여부", name = "IsMine")
-    private boolean isMine;
+    @Schema(description = "내 메시지 여부")
+    private boolean IsMine;
 
 
     public static ChatMessageBroadcast of(ChatMessage message, User sender, Long repositoryId, CodeReferenceResponse codeReference, Long currentUserId) {
@@ -56,7 +55,7 @@ public class ChatMessageBroadcast {
                 .message(message.getMessage())
                 .codeReference(codeReference)
                 .sentAt(message.getSentAt())
-                .isMine(sender.getId().equals(currentUserId))
+                .IsMine(sender.getId().equals(currentUserId))
                 .build();
     }
 
@@ -71,7 +70,7 @@ public class ChatMessageBroadcast {
                 .message(message)
                 .codeReference(null)
                 .sentAt(LocalDateTime.now())
-                .isMine(false)
+                .IsMine(false)
                 .build();
     }
 }

--- a/src/main/java/com/deepdirect/deepwebide_be/chat/dto/response/ChatMessageBroadcast.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/chat/dto/response/ChatMessageBroadcast.java
@@ -45,7 +45,7 @@ public class ChatMessageBroadcast {
     private boolean isMine;
 
 
-    public static ChatMessageBroadcast of(ChatMessage message, User sender, Long repositoryId, CodeReferenceResponse codeReference) {
+    public static ChatMessageBroadcast of(ChatMessage message, User sender, Long repositoryId, CodeReferenceResponse codeReference, Long currentUserId) {
         return ChatMessageBroadcast.builder()
                 .repositoryId(repositoryId)
                 .type(ChatMessageType.CHAT) //일반 채팅
@@ -56,7 +56,7 @@ public class ChatMessageBroadcast {
                 .message(message.getMessage())
                 .codeReference(codeReference)
                 .sentAt(message.getSentAt())
-                .isMine(false)
+                .isMine(sender.getId().equals(currentUserId))
                 .build();
     }
 

--- a/src/main/java/com/deepdirect/deepwebide_be/chat/service/ChatMessageWriteService.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/chat/service/ChatMessageWriteService.java
@@ -73,6 +73,6 @@ public class ChatMessageWriteService {
         // 3. 응답 DTO 변환
         CodeReferenceResponse codeReferenceResponse = reference != null ? CodeReferenceResponse.from(reference) : null;
 
-        return ChatMessageBroadcast.of(chatMessage, sender, repositoryId, codeReferenceResponse);
+        return ChatMessageBroadcast.of(chatMessage, sender, repositoryId, codeReferenceResponse, userId);
     }
 }

--- a/src/main/java/com/deepdirect/deepwebide_be/chat/util/RedisSubscriber.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/chat/util/RedisSubscriber.java
@@ -4,7 +4,6 @@ import com.deepdirect.deepwebide_be.chat.dto.response.ChatMessageBroadcast;
 import com.deepdirect.deepwebide_be.chat.dto.response.ChatSystemMessageResponse;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.sentry.Sentry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.connection.Message;
@@ -45,7 +44,7 @@ public class RedisSubscriber implements MessageListener {
                         .message(broadcast.getMessage())
                         .codeReference(broadcast.getCodeReference())
                         .sentAt(broadcast.getSentAt())
-                        .isMine(false)
+                        .IsMine(false)
                         .build();
 
                 messagingTemplate.convertAndSend("/sub/repositories/" + repositoryId + "/chat", response);

--- a/src/main/java/com/deepdirect/deepwebide_be/global/config/RedisConfig.java
+++ b/src/main/java/com/deepdirect/deepwebide_be/global/config/RedisConfig.java
@@ -25,7 +25,7 @@ public class RedisConfig {
     public RedisMessageListenerContainer redisMessageListenerContainer() {
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
         container.setConnectionFactory(connectionFactory);
-        container.addMessageListener(redisSubscriber, new PatternTopic("chat:*"));
+//        container.addMessageListener(redisSubscriber, new PatternTopic("chat:*"));
         return container;
     }
 


### PR DESCRIPTION
## 🔀 PR 제목

- [Fix] 실시간 채팅 Redis 채널 구독 및 메시지 처리 수정

---

## 📌 작업 내용 요약
어떤 작업을 했는지 간략히 설명해주세요.

예시:
- WebSocket 응답 메시지의 isMine=false 하드코딩 문제 수정
- Redis 채널명 불일치 수정 "chatroom:{repoId}" → "chat:{repoId}"
- Redis 채널 중복 구독 제거
- ChatMessageBroadcast DTO 내 isMine → IsMine 네이밍 수정

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
`Closes #이슈번호` 또는 `Related to #이슈번호` 형태로 작성

예시:
- Closes #이슈번호
- Related to #이슈번호
---

## 📎 기타 참고 사항
추가로 리뷰어가 참고해야 할 사항이 있다면 적어주세요.

예시:
- API 명세 변경사항 포함됨
- 테스트 코드는 다음 PR에서 작성 예정
